### PR TITLE
Always invoke callbacks in react methods before return

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,3 @@
-// Inspired by rayronvictor's PR #248 tp react-native-config
-// https://github.com/luggit/react-native-config/pull/248
-
-def _ext = rootProject.ext
-
 buildscript {
   repositories {
     maven {
@@ -14,11 +9,16 @@ buildscript {
   }
 
   dependencies {
-    classpath _ext.has('gradleBuildTools') ? _ext.gradleBuildTools : 'com.android.tools.build:gradle:3.4.0'
+    classpath 'com.android.tools.build:gradle:3.4.0'
   }
 }
 
 apply plugin: 'com.android.library'
+
+// Inspired by rayronvictor's PR #248 tp react-native-config
+// https://github.com/luggit/react-native-config/pull/248
+
+def _ext = rootProject.ext
 
 def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
 def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27

--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthConstants.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthConstants.java
@@ -9,5 +9,9 @@ public final class FingerprintAuthConstants {
     public static final int AUTHENTICATION_FAILED = 105;
     public static final int AUTHENTICATION_CANCELED = 106;
 
+    public static final int NO_ACTIVITY = 200;
+    public static final int ALREADY_IN_PROGRESS = 201;
+    public static final int APP_NOT_ACTIVE = 202;
+
     private FingerprintAuthConstants() {}
 }

--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -66,12 +66,17 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
     @TargetApi(Build.VERSION_CODES.M)
     @ReactMethod
     public void authenticate(final String reason, final ReadableMap authConfig, final Callback reactErrorCallback, final Callback reactSuccessCallback) {
+        final Activity activity = getCurrentActivity();
+
+        if (activity == null) {
+            reactErrorCallback.invoke("No activity", FingerprintAuthConstants.NO_ACTIVITY);
+        }
         if (inProgress) {
-            reactErrorCallback.invoke("Already in progress");
+            reactErrorCallback.invoke("Already in progress", FingerprintAuthConstants.ALREADY_IN_PROGRESS);
             return;
         }
         if (!isAppActive) {
-            reactErrorCallback.invoke("App is not active");
+            reactErrorCallback.invoke("App is not active", FingerprintAuthConstants.APP_NOT_ACTIVE);
             return;
         }
 
@@ -121,7 +126,7 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
 
         final Activity activity = getCurrentActivity();
         if (activity == null) {
-            return FingerprintAuthConstants.NOT_AVAILABLE; // we can't do the check
+            return FingerprintAuthConstants.NO_ACTIVITY; // we can't do the check
         }
 
         final KeyguardManager keyguardManager = getKeyguardManager();

--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -52,11 +52,6 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
 
     @ReactMethod
     public void isSupported(final Callback reactErrorCallback, final Callback reactSuccessCallback) {
-        final Activity activity = getCurrentActivity();
-        if (activity == null) {
-            return;
-        }
-
         int result = isFingerprintAuthAvailable();
         if (result == FingerprintAuthConstants.IS_SUPPORTED) {
             // TODO: once this package supports Android's Face Unlock,
@@ -71,10 +66,15 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
     @TargetApi(Build.VERSION_CODES.M)
     @ReactMethod
     public void authenticate(final String reason, final ReadableMap authConfig, final Callback reactErrorCallback, final Callback reactSuccessCallback) {
-        final Activity activity = getCurrentActivity();
-        if (inProgress || !isAppActive || activity == null) {
+        if (inProgress) {
+            reactErrorCallback.invoke("Already in progress");
             return;
         }
+        if (!isAppActive) {
+            reactErrorCallback.invoke("App is not active");
+            return;
+        }
+
         inProgress = true;
 
         int availableResult = isFingerprintAuthAvailable();
@@ -107,6 +107,7 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule implements
 
         if (!isAppActive) {
             inProgress = false;
+            reactErrorCallback.invoke("App is not active");
             return;
         }
 

--- a/data/errors.js
+++ b/data/errors.js
@@ -30,7 +30,11 @@ const codes = {
     NOT_AVAILABLE: 'NOT_AVAILABLE',
     NOT_ENROLLED: 'NOT_ENROLLED',
     AUTHENTICATION_FAILED: 'AUTHENTICATION_FAILED',
-    AUTHENTICATION_CANCELED: 'AUTHENTICATION_CANCELED'
+    AUTHENTICATION_CANCELED: 'AUTHENTICATION_CANCELED',
+
+    NO_ACTIVITY: 'NO_ACTIVITY',
+    ALREADY_IN_PROGRESS: 'ALREADY_IN_PROGRESS',
+    APP_NOT_ACTIVE: 'APP_NOT_ACTIVE'
   }
 };
 
@@ -86,7 +90,11 @@ const androidModuleErrorMap = {
   103: codes.androidModuleCodes.NOT_AVAILABLE,
   104: codes.androidModuleCodes.NOT_ENROLLED,
   105: codes.androidModuleCodes.AUTHENTICATION_FAILED,
-  106: codes.androidModuleCodes.AUTHENTICATION_CANCELED
+  106: codes.androidModuleCodes.AUTHENTICATION_CANCELED,
+
+  200: codes.androidModuleCodes.NO_ACTIVITY,
+  201: codes.androidModuleCodes.ALREADY_IN_PROGRESS,
+  202: codes.androidModuleCodes.APP_NOT_ACTIVE
 };
 
 const errors = {


### PR DESCRIPTION
Android: App stucks when unlocking the phone where sometimes caused by calling `isSupported` before activity was started - no callback was invoked in that case 😅 

